### PR TITLE
Chapter 8 updates

### DIFF
--- a/ch08/print-name/Cargo.toml
+++ b/ch08/print-name/Cargo.toml
@@ -3,3 +3,4 @@ members = [
     "print_name",
     "print_name_derive"
 ]
+resolver = "2"


### PR DESCRIPTION
Updated print-name:
- Added resolver = "2" to Cargo.toml to use the edition 2021 resolver