### PR TITLE
Ch8 fix print name remove trait bounds

### DIFF
--- a/ch08/print-name/print_name_derive/src/lib.rs
+++ b/ch08/print-name/print_name_derive/src/lib.rs
@@ -2,17 +2,14 @@
 // https://github.com/dtolnay/syn/tree/master/examples/heapsize.
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{
-    parse_macro_input, parse_quote, DeriveInput, GenericParam, Generics,
-};
+use syn::{parse_macro_input, DeriveInput};
 
 #[proc_macro_derive(PrintName)]
 pub fn print_name(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
-    let generics = add_trait_bounds(input.generics);
     let (impl_generics, type_generics, where_clause) =
-        generics.split_for_impl();
+        input.generics.split_for_impl();
 
     let name = input.ident;
 
@@ -25,13 +22,4 @@ pub fn print_name(input: TokenStream) -> TokenStream {
     };
 
     TokenStream::from(expanded)
-}
-
-fn add_trait_bounds(mut generics: Generics) -> Generics {
-    for param in &mut generics.params {
-        if let GenericParam::Type(ref mut type_param) = *param {
-            type_param.bounds.push(parse_quote!(print_name::PrintName));
-        }
-    }
-    generics
 }

--- a/ch08/print-name/print_name_derive/tests/test_derive.rs
+++ b/ch08/print-name/print_name_derive/tests/test_derive.rs
@@ -1,11 +1,21 @@
 use print_name::PrintName;
 use print_name_derive::PrintName;
+use std::marker::PhantomData;
 
 #[test]
 fn test_derive() {
     #[derive(PrintName)]
     struct MyStruct;
 
+    #[derive(PrintName)]
+    struct MyGenericStruct<T> {
+        phantom: PhantomData<T>,
+    }
+
     assert_eq!(MyStruct::name(), "MyStruct");
     MyStruct::print_name();
+    assert_eq!(MyGenericStruct::<i64>::name(), "MyGenericStruct");
+    assert_eq!(MyGenericStruct::<i128>::name(), "MyGenericStruct");
+    assert_eq!(MyGenericStruct::<String>::name(), "MyGenericStruct");
+    MyGenericStruct::<i128>::print_name();
 }


### PR DESCRIPTION
Updated print-name:
    - Removed trait bounds from the macro, as it doesn't make sense in
      this case, as it did in the original example in syn.
    - Updated macro tests to test generic structs cases.